### PR TITLE
Add toast helper methods for save flow

### DIFF
--- a/index.html
+++ b/index.html
@@ -648,6 +648,7 @@ class StockVerificationApp {
     this.SYNC_INTERVAL = window.CONFIG.SYNC_INTERVAL || 30000;
     this.currentRoute = '';
     this.productCatalog = {};
+    this.toastTimer = null;
   }
 
   // simple GET/POST (no preflight)
@@ -865,7 +866,7 @@ class StockVerificationApp {
 
   // Save to backend route tab
   async saveData(isSubmit){
-    if (!this.currentRoute){ this.toast('Select a route','error'); return; }
+    if (!this.currentRoute){ this.showToast('Select a route','error'); return; }
     const items=[];
     Object.entries(this.productCatalog).forEach(([category,products])=>{
       products.forEach(it=>{
@@ -893,6 +894,30 @@ class StockVerificationApp {
       if (res.status==='success'){ this.updateSyncStatus('connected'); this.showToast(isSubmit?'Submitted!':'Saved!','success'); }
       else throw new Error(res.data||'Save failed');
     } catch(e){ this.updateSyncStatus('disconnected'); this.showToast('Save failed: '+e.message,'error'); }
+  }
+
+  showToast(message, type='info', duration=3000){
+    const toastEl = document.getElementById('toast');
+    if (!toastEl) return;
+
+    if (this.toastTimer){
+      clearTimeout(this.toastTimer);
+      this.toastTimer = null;
+    }
+
+    toastEl.textContent = message;
+    toastEl.className = 'toast';
+    if (type) toastEl.classList.add(type);
+    toastEl.classList.add('show');
+
+    this.toastTimer = setTimeout(()=>{
+      toastEl.classList.remove('show','success','error','info','warning');
+      this.toastTimer = null;
+    }, duration);
+  }
+
+  toast(...args){
+    this.showToast(...args);
   }
 
   updateSyncStatus(state){


### PR DESCRIPTION
## Summary
- add toast helper methods on the StockVerificationApp to drive the toast UI
- ensure saveData uses the toast helper while preserving future compatibility

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_b_68d7e70a2a648326903cec80831443b5