### PR TITLE
Add toast helper for StockVerificationApp notifications

### DIFF
--- a/index.html
+++ b/index.html
@@ -648,6 +648,7 @@ class StockVerificationApp {
     this.SYNC_INTERVAL = window.CONFIG.SYNC_INTERVAL || 30000;
     this.currentRoute = '';
     this.productCatalog = {};
+    this.toastTimer = null;
   }
 
   // simple GET/POST (no preflight)
@@ -885,14 +886,38 @@ class StockVerificationApp {
         }
       });
     });
-    if (!items.length){ this.showToast('Nothing to save','warning'); return; }
+    if (!items.length){ this.toast('Nothing to save','warning'); return; }
 
     this.updateSyncStatus('syncing');
     try{
       const res = await this.post('saveInventoryData', { route:this.currentRoute, date:this.today, items });
-      if (res.status==='success'){ this.updateSyncStatus('connected'); this.showToast(isSubmit?'Submitted!':'Saved!','success'); }
+      if (res.status==='success'){ this.updateSyncStatus('connected'); this.toast(isSubmit?'Submitted!':'Saved!','success'); }
       else throw new Error(res.data||'Save failed');
-    } catch(e){ this.updateSyncStatus('disconnected'); this.showToast('Save failed: '+e.message,'error'); }
+    } catch(e){ this.updateSyncStatus('disconnected'); this.toast('Save failed: '+e.message,'error'); }
+  }
+
+  toast(message, type='info', duration=3000){
+    this.showToast(message, type, duration);
+  }
+  showToast(message, type='info', duration=3000){
+    const toast = document.getElementById('toast');
+    if (!toast) return;
+
+    if (this.toastTimer){
+      clearTimeout(this.toastTimer);
+      this.toastTimer = null;
+    }
+
+    toast.textContent = message;
+    toast.className = 'toast';
+    if (type) toast.classList.add(type);
+    toast.classList.add('show');
+
+    this.toastTimer = setTimeout(()=>{
+      toast.classList.remove('show');
+      ['success','error','info','warning'].forEach(cls=>toast.classList.remove(cls));
+      this.toastTimer = null;
+    }, duration);
   }
 
   updateSyncStatus(state){


### PR DESCRIPTION
## Summary
- add toast helper methods to StockVerificationApp for consistent notification rendering
- clear and reuse toast timers to manage visibility and styling of the #toast element
- update saveData to call the new helper for all success and error messaging

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_b_68d7e992ff508326912492a65949e687